### PR TITLE
Slice: Optimize slice func tools

### DIFF
--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -237,10 +237,8 @@ func TestIntSlice(t *testing.T) {
 }
 
 func intSlice(t *testing.T, test interface{}, expected []int) {
-	res, err := IntSlice(test)
-	if err != nil {
-		t.Error("IntSlice Error: " + err.Error())
-	}
+	res := IntSlice(test)
+
 	if !reflect.DeepEqual(res, expected) {
 		utils.LogFailedTestInfo(t, "IntSlice", test, expected, res)
 		t.FailNow()


### PR DESCRIPTION
IntSlice and StringSlice: preallocate memory up front for output slice.
Instead returning a error throw a panic because most likely it's a
programming error.
Contain: rename slice to iterableType and add default case for type
mismatches