### PR TITLE
feat: support type alias for Number constraint

### DIFF
--- a/lancetconstraints/constraints.go
+++ b/lancetconstraints/constraints.go
@@ -14,5 +14,5 @@ type Comparator interface {
 
 // Number contains all types of number and uintptr, used for generics constraint
 type Number interface {
-	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | uintptr | float32 | float64
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64
 }

--- a/mathutil/mathutil_test.go
+++ b/mathutil/mathutil_test.go
@@ -87,6 +87,9 @@ func TestMax(t *testing.T) {
 	assert.Equal(Max(0, 0), 0)
 	assert.Equal(Max(1, 2, 3), 3)
 	assert.Equal(Max(1.2, 1.4, 1.1, 1.4), 1.4)
+
+	type Integer int
+	assert.Equal(Max(Integer(1), Integer(0)), Integer(1))
 }
 
 func TestMaxBy(t *testing.T) {


### PR DESCRIPTION
Support type alias for Number constraint. eg:
```go
func TestMax() {
    type Integer int
    assert.Equal(Max(Integer(1), Integer(0)), Integer(1))
}
```