### PR TITLE
Add StructUtil for provide more rich functions 

### DIFF
--- a/convertor/convertor.go
+++ b/convertor/convertor.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/duke-git/lancet/v2/structutil"
 	"math"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -235,32 +235,7 @@ func ToMap[T any, K comparable, V any](array []T, iteratee func(T) (K, V)) map[K
 // map key is specified same as struct field tag `json` value.
 // Play: https://go.dev/play/p/KYGYJqNUBOI
 func StructToMap(value any) (map[string]any, error) {
-	v := reflect.ValueOf(value)
-	t := reflect.TypeOf(value)
-
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	if t.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("data type %T not support, shuld be struct or pointer to struct", value)
-	}
-
-	result := make(map[string]any)
-
-	fieldNum := t.NumField()
-	pattern := `^[A-Z]`
-	regex := regexp.MustCompile(pattern)
-	for i := 0; i < fieldNum; i++ {
-		name := t.Field(i).Name
-		tag := t.Field(i).Tag.Get("json")
-		if tag == "" || strings.HasPrefix(tag, "-") || !regex.MatchString(name) {
-			continue
-		}
-		tag = strings.Split(tag, ",")[0]
-		result[tag] = v.Field(i).Interface()
-	}
-
-	return result, nil
+	return structutil.ToMap(value)
 }
 
 // MapToSlice convert map to slice based on iteratee function.

--- a/convertor/convertor.go
+++ b/convertor/convertor.go
@@ -253,10 +253,11 @@ func StructToMap(value any) (map[string]any, error) {
 	for i := 0; i < fieldNum; i++ {
 		name := t.Field(i).Name
 		tag := t.Field(i).Tag.Get("json")
-		if regex.MatchString(name) && tag != "" {
-			//result[name] = v.Field(i).Interface()
-			result[tag] = v.Field(i).Interface()
+		if tag == "" || strings.HasPrefix(tag, "-") || !regex.MatchString(name) {
+			continue
 		}
+		tag = strings.Split(tag, ",")[0]
+		result[tag] = v.Field(i).Interface()
 	}
 
 	return result, nil

--- a/convertor/convertor_test.go
+++ b/convertor/convertor_test.go
@@ -180,7 +180,7 @@ func TestToMap(t *testing.T) {
 func TestStructToMap(t *testing.T) {
 	assert := internal.NewAssert(t, "TestStructToMap")
 
-	t.Run("StructToMap", func(t *testing.T) {
+	t.Run("StructToMap", func(_ *testing.T) {
 		type People struct {
 			Name string `json:"name"`
 			age  int
@@ -194,7 +194,7 @@ func TestStructToMap(t *testing.T) {
 		assert.Equal(expected, pm)
 	})
 
-	t.Run("StructToMapWithJsonAttr", func(t *testing.T) {
+	t.Run("StructToMapWithJsonAttr", func(_ *testing.T) {
 		type People struct {
 			Name  string `json:"name,omitempty"` // json tag with attribute
 			Phone string `json:"phone"`          // json tag without attribute
@@ -202,13 +202,12 @@ func TestStructToMap(t *testing.T) {
 			age   int    // no tag
 		}
 		p := People{
-			"test",
-			"1111",
-			"male",
-			100,
+			Phone: "1111",
+			Sex:   "male",
+			age:   100,
 		}
 		pm, _ := StructToMap(p)
-		var expected = map[string]any{"name": "test", "phone": "1111"}
+		var expected = map[string]any{"phone": "1111"}
 		assert.Equal(expected, pm)
 	})
 }

--- a/convertor/convertor_test.go
+++ b/convertor/convertor_test.go
@@ -180,18 +180,37 @@ func TestToMap(t *testing.T) {
 func TestStructToMap(t *testing.T) {
 	assert := internal.NewAssert(t, "TestStructToMap")
 
-	type People struct {
-		Name string `json:"name"`
-		age  int
-	}
-	p := People{
-		"test",
-		100,
-	}
-	pm, _ := StructToMap(p)
+	t.Run("StructToMap", func(t *testing.T) {
+		type People struct {
+			Name string `json:"name"`
+			age  int
+		}
+		p := People{
+			"test",
+			100,
+		}
+		pm, _ := StructToMap(p)
+		var expected = map[string]any{"name": "test"}
+		assert.Equal(expected, pm)
+	})
 
-	expected := map[string]any{"name": "test"}
-	assert.Equal(expected, pm)
+	t.Run("StructToMapWithJsonAttr", func(t *testing.T) {
+		type People struct {
+			Name  string `json:"name,omitempty"` // json tag with attribute
+			Phone string `json:"phone"`          // json tag without attribute
+			Sex   string `json:"-"`              // ignore
+			age   int    // no tag
+		}
+		p := People{
+			"test",
+			"1111",
+			"male",
+			100,
+		}
+		pm, _ := StructToMap(p)
+		var expected = map[string]any{"name": "test", "phone": "1111"}
+		assert.Equal(expected, pm)
+	})
 }
 
 func TestMapToSlice(t *testing.T) {

--- a/netutil/http_test.go
+++ b/netutil/http_test.go
@@ -217,17 +217,22 @@ func TestStructToUrlValues(t *testing.T) {
 	assert := internal.NewAssert(t, "TestStructToUrlValues")
 
 	type TodoQuery struct {
-		Id     int `json:"id"`
-		UserId int `json:"userId"`
+		Id     int    `json:"id"`
+		UserId int    `json:"userId"`
+		Name   string `json:"name,omitempty"`
 	}
 	todoQuery := TodoQuery{
 		Id:     1,
 		UserId: 1,
 	}
-	todoValues := StructToUrlValues(todoQuery)
+	todoValues, err := StructToUrlValues(todoQuery)
+	if err != nil {
+		t.Errorf("params is invalid: %v", err)
+	}
 
 	assert.Equal("1", todoValues.Get("id"))
 	assert.Equal("1", todoValues.Get("userId"))
+	assert.Equal("", todoValues.Get("name"))
 
 	request := &HttpRequest{
 		RawURL:      "https://jsonplaceholder.typicode.com/todos",

--- a/netutil/net_example_test.go
+++ b/netutil/net_example_test.go
@@ -123,14 +123,17 @@ func ExampleHttpClient_DecodeResponse() {
 
 func ExampleStructToUrlValues() {
 	type TodoQuery struct {
-		Id   int    `json:"id"`
+		Id   int    `json:"id,omitempty"`
 		Name string `json:"name"`
 	}
 	todoQuery := TodoQuery{
 		Id:   1,
 		Name: "Test",
 	}
-	todoValues := StructToUrlValues(todoQuery)
+	todoValues, err := StructToUrlValues(todoQuery)
+	if err != nil {
+		return
+	}
 
 	fmt.Println(todoValues.Get("id"))
 	fmt.Println(todoValues.Get("name"))

--- a/retry/retry_example_test.go
+++ b/retry/retry_example_test.go
@@ -19,14 +19,10 @@ func ExampleContext() {
 		return errors.New("error occurs")
 	}
 
-	err := Retry(increaseNumber,
+	Retry(increaseNumber,
 		RetryDuration(time.Microsecond*50),
 		Context(ctx),
 	)
-
-	if err != nil {
-		return
-	}
 
 	fmt.Println(number)
 

--- a/structutil/field.go
+++ b/structutil/field.go
@@ -1,0 +1,55 @@
+package structutil
+
+import "reflect"
+
+type Field struct {
+	value reflect.Value
+	field reflect.StructField
+	tag   *Tag
+}
+
+func newField(v reflect.Value, f reflect.StructField, tagName string) *Field {
+	tag := f.Tag.Get(tagName)
+	return &Field{
+		value: v,
+		field: f,
+		tag:   newTag(tag),
+	}
+}
+
+// Tag returns the value that the key in the tag string.
+func (f *Field) Tag() *Tag {
+	return f.tag
+}
+
+// Value returns the underlying value of the field.
+func (f *Field) Value() any {
+	return f.value.Interface()
+}
+
+// IsEmbedded returns true if the given field is an embedded field.
+func (f *Field) IsEmbedded() bool {
+	return f.field.Anonymous
+}
+
+// IsExported returns true if the given field is exported.
+func (f *Field) IsExported() bool {
+	return f.field.PkgPath == ""
+}
+
+// IsZero returns true if the given field is zero value.
+func (f *Field) IsZero() bool {
+	z := reflect.Zero(f.value.Type()).Interface()
+	v := f.Value()
+	return reflect.DeepEqual(z, v)
+}
+
+// Name returns the name of the given field
+func (f *Field) Name() string {
+	return f.field.Name
+}
+
+// Kind returns the field's kind
+func (f *Field) Kind() reflect.Kind {
+	return f.value.Kind()
+}

--- a/structutil/struct.go
+++ b/structutil/struct.go
@@ -1,0 +1,88 @@
+package structutil
+
+import (
+	"reflect"
+)
+
+// DefaultTagName is the default tag for struct fields to lookup.
+var DefaultTagName = "json"
+
+// Struct is abstract struct for provide several high level functions
+type Struct struct {
+	raw     any
+	rtype   reflect.Type
+	rvalue  reflect.Value
+	TagName string
+}
+
+// New returns a new *Struct
+func New(value any) *Struct {
+	v := reflect.ValueOf(value)
+	t := reflect.TypeOf(value)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	return &Struct{
+		raw:     value,
+		rtype:   t,
+		rvalue:  v,
+		TagName: DefaultTagName,
+	}
+}
+
+// ToMap converts the given struct to a map[string]any, where the keys
+// of the keys are the field names and the values of the map are the values
+// of the fields. The default map key is the struct field name, but you can
+// change it. The `json` key is the default tag key. Example:
+//
+//		// default
+//		Name string `json:"name"`
+//
+//		// ignore the field
+//		Name string							// no tag
+//	 	Age string `json:"-"`				// json ignore tag
+//		sex string							// unexported field
+//	 	Goal int   `json:"goal,omitempty"`  // omitempty if the field is zero value
+//
+//	 	// custom map key
+//	 	Name string `json:"myName"`
+//
+// Only the exported fields of a struct can be converted.
+func (s *Struct) ToMap() (map[string]any, error) {
+	result := make(map[string]any)
+
+	fields := s.Fields()
+	for _, f := range fields {
+		if !f.IsExported() || f.tag.IsEmpty() || f.tag.Name == "-" {
+			continue
+		}
+		if f.IsZero() && f.tag.HasOption("omitempty") {
+			continue
+		}
+		// TODO: sub struct
+		result[f.tag.Name] = f.Value()
+	}
+
+	return result, nil
+}
+
+// Fields returns all the struct fields within a slice
+func (s *Struct) Fields() []*Field {
+
+	var fields []*Field
+	fieldNum := s.rvalue.NumField()
+	for i := 0; i < fieldNum; i++ {
+		v := s.rvalue.Field(i)
+		sf := s.rtype.Field(i)
+		field := newField(v, sf, DefaultTagName)
+		fields = append(fields, field)
+	}
+
+	return fields
+}
+
+// ToMap convert struct to map, only convert exported struct field
+// map key is specified same as struct field tag `json` value.
+func ToMap(v any) (map[string]any, error) {
+	return New(v).ToMap()
+}

--- a/structutil/struct_test.go
+++ b/structutil/struct_test.go
@@ -1,0 +1,57 @@
+package structutil
+
+import (
+	"github.com/duke-git/lancet/v2/internal"
+	"testing"
+)
+
+func TestToMap(t *testing.T) {
+	assert := internal.NewAssert(t, "TestStructToMap")
+
+	t.Run("StructToMap", func(_ *testing.T) {
+		type People struct {
+			Name string `json:"name"`
+			age  int
+		}
+		p := People{
+			"test",
+			100,
+		}
+		pm, _ := ToMap(p)
+		var expected = map[string]any{"name": "test"}
+		assert.Equal(expected, pm)
+	})
+
+	t.Run("StructToMapWithJsonAttr", func(_ *testing.T) {
+		type People struct {
+			Name      string `json:"name,omitempty"` // json tag with attribute
+			Phone     string `json:"phone"`          // json tag without attribute
+			Sex       string `json:"-"`              // ignore by "-"
+			Age       int    // ignore by no tag
+			email     string // ignore by unexported
+			IsWorking bool   `json:"is_working"`
+		}
+		p1 := People{
+			Name:  "AAA", // exist
+			Phone: "1111",
+			Sex:   "male",
+			Age:   100,
+			email: "11@gmail.com",
+		}
+		p1m, _ := ToMap(p1)
+		var expect1 = map[string]any{"name": "AAA", "phone": "1111", "is_working": false}
+		assert.Equal(expect1, p1m)
+
+		p2 := People{
+			Name:      "",
+			Phone:     "2222",
+			Sex:       "male",
+			Age:       0,
+			email:     "22@gmail.com",
+			IsWorking: true,
+		}
+		p2m, _ := ToMap(p2)
+		var expect2 = map[string]any{"phone": "2222", "is_working": true}
+		assert.Equal(expect2, p2m)
+	})
+}

--- a/structutil/tag.go
+++ b/structutil/tag.go
@@ -1,0 +1,32 @@
+package structutil
+
+import (
+	"github.com/duke-git/lancet/v2/validator"
+	"strings"
+)
+
+type Tag struct {
+	Name    string
+	Options []string
+}
+
+func newTag(tag string) *Tag {
+	res := strings.Split(tag, ",")
+	return &Tag{
+		Name:    res[0],
+		Options: res[1:],
+	}
+}
+
+func (t *Tag) HasOption(opt string) bool {
+	for _, o := range t.Options {
+		if o == opt {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *Tag) IsEmpty() bool {
+	return validator.IsEmptyString(t.Name)
+}


### PR DESCRIPTION
## feature
目前对于struct的转换方法写的比较简陋，考虑到struct的方法可能会很多，所以抽象出来单独封装，便于维护，整体逻辑大致如下：

- 封装`Struct`对象作为抽象，作为对外统一暴露方法的结构体
- 封装`Field`为`Struct`的属性，提供若干方便的方法
- 封装`Tag`为`Field`的标签，提供若干边界方法

`Struct`目前提供方法有：
```go
// 将struct转换为map
// 做了一部分优化，同时修复了 #77
ToMap(v any) (map[string]any, error)

// 提供获取struct的属性列表方法，此属性为为封装`Field`
Fields() []*Fields
```

`Field`目前提供方法：
```go
// 获取Field抽象Tag对象
Tag() *Tag

// 获取Field值
Value() any

// 判断是否为嵌入属性
IsEmbedded() bool

// 判断属性是否公开
IsExported() bool

// 判断属性是否零值
IsZero() bool

// 获取属性名
Name() string

// 获取Kind
Kind() reflect.Kind
```

`Tag`目前提供方法：
```go
// 判断tag选项
HasOption(opt string) bool

// 判断是否为空tag
IsEmpty() bool
```

## migrate
将convertor中的StructToMap逻辑迁移至`structutil`中的`ToMap`，为兼容老版本提供方法暂留。

## fixed
修复#77

