### PR TITLE
feat: add UnwarpOr and UnwarpOrDefault to pointer pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,6 +968,12 @@ import "github.com/duke-git/lancet/v2/pointer"
 -   **<big>Unwrap</big>** : return the value from the pointer.
     [[doc](https://github.com/duke-git/lancet/blob/main/docs/pointer.md#Unwrap)]
     [[play](https://go.dev/play/p/cgeu3g7cjWb)]
+-   **<big>UnwarpOr</big>** : UnwarpOr returns the value from the pointer or fallback if the pointer is nil.
+    [[doc](https://github.com/duke-git/lancet/blob/main/docs/pointer.md#UnwrapOr)]
+    [[play](https://go.dev/play/p/mmNaLC38W8C)]
+-   **<big>UnwarpOrDefault</big>** : UnwarpOrDefault returns the value from the pointer or the default value if the pointer is nil.
+    [[doc](https://github.com/duke-git/lancet/blob/main/docs/pointer.md#UnwrapOrDefault)]
+    [[play](https://go.dev/play/p/ZnGIHf8_o4E)]
 
 <h3 id="Random"> 16. Random package implements some basic functions to generate random int and string. &nbsp; &nbsp; &nbsp; &nbsp;<a href="#index">index</a></h3>
 

--- a/docs/pointer.md
+++ b/docs/pointer.md
@@ -24,6 +24,8 @@ import (
 
 -   [Of](#Of)
 -   [Unwrap](#Unwrap)
+-   [UnwarpOr](#UnwarpOr)
+-   [UnwarpOrDefault](#UnwarpOrDefault)
 -   [ExtractPointer](#ExtractPointer)
 
 <div STYLE="page-break-after: always;"></div>
@@ -99,6 +101,99 @@ func main() {
     // abc
 }
 ```
+
+
+### <span id="UnwarpOr">UnwarpOr</span>
+
+<p>Returns the value from the pointer or fallback if the pointer is nil.</p>
+
+<b>Signature:</b>
+```go
+UnwarpOr[T any](p *T, fallback T) T
+```
+
+<b>Example:</b>
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/duke-git/lancet/v2/pointer"
+)
+
+func main() {
+	a := 123
+	b := "abc"
+
+	var c *int
+	var d *string
+
+	result1 := pointer.UnwarpOr(&a, 456)
+	result2 := pointer.UnwarpOr(&b, "abc")
+	result3 := pointer.UnwarpOr(c, 456)
+	result4 := pointer.UnwarpOr(d, "def")
+
+	fmt.Println(result1)
+	fmt.Println(result2)
+	fmt.Println(result3)
+	fmt.Println(result4)
+
+	// Output:
+	// 123
+	// abc
+	// 456
+	// def
+}
+```
+
+--- ord derad
+
+
+### <span id="UnwarpOrDefault">UnwarpOrDefault</span>
+
+<p>Returns the value from the pointer or the default value if the pointer is nil.</p>
+
+<b>Signature:</b>
+```go
+UnwarpOrDefault[T any](p *T) T
+```
+
+<b>Example:</b>
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/duke-git/lancet/v2/pointer"
+)
+
+func main() {
+	a := 123
+	b := "abc"
+
+	var c *int
+	var d *string
+
+	result1 := pointer.UnwarpOrDefault(&a)
+	result2 := pointer.UnwarpOrDefault(&b)
+	result3 := pointer.UnwarpOrDefault(c)
+	result4 := pointer.UnwarpOrDefault(d)
+
+	fmt.Println(result1)
+	fmt.Println(result2)
+	fmt.Println(result3)
+	fmt.Println(result4)
+
+	// Output:
+	// 123
+	// abc
+	// 0
+	//
+}
+```
+
 
 ### <span id="ExtractPointer">ExtractPointer</span>
 

--- a/pointer/pointer.go
+++ b/pointer/pointer.go
@@ -18,6 +18,26 @@ func Unwrap[T any](p *T) T {
 	return *p
 }
 
+// UnwarpOr returns the value from the pointer or fallback if the pointer is nil.
+// Play: https://go.dev/play/p/mmNaLC38W8C
+func UnwarpOr[T any](p *T, fallback T) T {
+	if p == nil {
+		return fallback
+	}
+	return *p
+}
+
+// UnwarpOrDefault returns the value from the pointer or the default value if the pointer is nil.
+// Play: https://go.dev/play/p/ZnGIHf8_o4E
+func UnwarpOrDefault[T any](p *T) T {
+	var v T
+
+	if p == nil {
+		return v
+	}
+	return *p
+}
+
 // ExtractPointer returns the underlying value by the given interface type
 // Play: https://go.dev/play/p/D7HFjeWU2ZP
 func ExtractPointer(value any) any {

--- a/pointer/pointer_examples_test.go
+++ b/pointer/pointer_examples_test.go
@@ -29,6 +29,54 @@ func ExampleUnwrap() {
 	// abc
 }
 
+func ExampleUnwarpOr() {
+	a := 123
+	b := "abc"
+
+	var c *int
+	var d *string
+
+	result1 := UnwarpOr(&a, 456)
+	result2 := UnwarpOr(&b, "abc")
+	result3 := UnwarpOr(c, 456)
+	result4 := UnwarpOr(d, "def")
+
+	fmt.Println(result1)
+	fmt.Println(result2)
+	fmt.Println(result3)
+	fmt.Println(result4)
+
+	// Output:
+	// 123
+	// abc
+	// 456
+	// def
+}
+
+func ExampleUnwarpOrDefault() {
+	a := 123
+	b := "abc"
+
+	var c *int
+	var d *string
+
+	result1 := UnwarpOrDefault(&a)
+	result2 := UnwarpOrDefault(&b)
+	result3 := UnwarpOrDefault(c)
+	result4 := UnwarpOrDefault(d)
+
+	fmt.Println(result1)
+	fmt.Println(result2)
+	fmt.Println(result3)
+	fmt.Println(result4)
+
+	// Output:
+	// 123
+	// abc
+	// 0
+	//
+}
+
 func ExampleExtractPointer() {
 	a := 1
 	b := &a

--- a/pointer/pointer_test.go
+++ b/pointer/pointer_test.go
@@ -30,6 +30,40 @@ func TestUnwrap(t *testing.T) {
 	assert.Equal(b, Unwrap(&b))
 }
 
+func TestUnwarpOr(t *testing.T) {
+	t.Parallel()
+
+	assert := internal.NewAssert(t, "TestUnwarpOr")
+
+	a := 123
+	b := "abc"
+
+	var c *int
+	var d *string
+
+	assert.Equal(a, UnwarpOr(&a, 456))
+	assert.Equal(b, UnwarpOr(&b, "abc"))
+	assert.Equal(456, UnwarpOr(c, 456))
+	assert.Equal("def", UnwarpOr(d, "def"))
+}
+
+func TestUnwarpOrDefault(t *testing.T) {
+	t.Parallel()
+
+	assert := internal.NewAssert(t, "TestUnwarpOrDefault")
+
+	a := 123
+	b := "abc"
+
+	var c *int
+	var d *string
+
+	assert.Equal(a, UnwarpOrDefault(&a))
+	assert.Equal(b, UnwarpOrDefault(&b))
+	assert.Equal(0, UnwarpOrDefault(c))
+	assert.Equal("", UnwarpOrDefault(d))
+}
+
 func TestExtractPointer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When I try to use `Unwarp` in the `pointer` package, it panics when I pass it a nil pointer.

This is not what I want; I want it to return a zero value of the pointer's type.
Or the fallback value I provide.


So I created two new functions, `UnwarpOr` and `UnwarpOrDefault`, to do this.

1. If the pointer is nil, `UnwarpOr` will return the fallback value.
2. If the pointer is nil, `UnwarpOrDefault` will return the zero value of the type of the pointer.

