### PR TITLE
fix the bug in cloning slices

### DIFF
--- a/convertor/convertor_internal.go
+++ b/convertor/convertor_internal.go
@@ -99,7 +99,7 @@ func (c *cloner) cloneArray(v reflect.Value) reflect.Value {
 	for i := 0; i < v.Len(); i++ {
 		val := c.clone(v.Index(i))
 
-		if val.IsValid() {
+		if !val.IsValid() {
 			continue
 		}
 

--- a/convertor/convertor_test.go
+++ b/convertor/convertor_test.go
@@ -337,6 +337,7 @@ func TestDeepClone(t *testing.T) {
 			Nil:   nil,
 			// unexported: "can't be cloned",
 		},
+		[]interface{}{1, &Struct{Str: "test"}, Struct{Str: "test2"}},
 	}
 
 	for i, item := range cases {


### PR DESCRIPTION
Skip invalid elements instead of valid elements when cloning a slice or an array.