### PR TITLE
feat: add support for seeking and read one line at a time from file

### DIFF
--- a/fileutil/file.go
+++ b/fileutil/file.go
@@ -563,6 +563,25 @@ func FileSize(path string) (int64, error) {
 	return f.Size(), nil
 }
 
+// DirSize walks the folder recursively and returns folder size in bytes.
+func DirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.WalkDir(path, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
+}
+
 // MTime returns file modified time.
 // Play: https://go.dev/play/p/s_Tl7lZoAaY
 func MTime(filepath string) (int64, error) {

--- a/fileutil/file_test.go
+++ b/fileutil/file_test.go
@@ -476,3 +476,42 @@ Disallow: /deny
 `
 	internal.NewAssert(t, "TestReadFile").Equal(want, string(dat))
 }
+
+func TestReadlineFile(t *testing.T) {
+	path := "./testdata/demo.csv"
+	reader, err := NewFileReader(path)
+	if err != nil {
+		t.Fail()
+	}
+	defer reader.Close()
+
+	indexMap := make(map[string]int64)
+	defer reader.Close()
+	for {
+		offset := reader.Offset()
+		line, err := reader.ReadLine()
+		if err == io.EOF {
+			break
+		}
+		indexMap[line] = offset
+	}
+
+	lines, err := ReadFileByLine(path)
+	if err != nil {
+		t.Fail()
+	}
+	for _, line := range lines {
+		offset, ok := indexMap[line]
+		if !ok {
+			t.Fail()
+		}
+		if err = reader.Seek(offset); err != nil {
+			t.Fail()
+		}
+		lineRead, err := reader.ReadLine()
+		if err == io.EOF {
+			break
+		}
+		internal.NewAssert(t, "TestReadlineFile").Equal(line, lineRead)
+	}
+}


### PR DESCRIPTION
* Add support for seeking files and reading files one line at a time, sample usage is demonstrated in `fileutil/file_test.go`
* Add support for calculating folder's size recursively

This should implement #156 