### PR TITLE
Add retry backoff policy

### DIFF
--- a/retry/retry_example_test.go
+++ b/retry/retry_example_test.go
@@ -20,7 +20,7 @@ func ExampleContext() {
 	}
 
 	Retry(increaseNumber,
-		RetryDuration(time.Microsecond*50),
+		RetryWithLinearBackoff(time.Microsecond*50),
 		Context(ctx),
 	)
 
@@ -30,7 +30,7 @@ func ExampleContext() {
 	// 4
 }
 
-func ExampleRetryDuration() {
+func ExampleRetryWithLinearBackoff() {
 	number := 0
 	increaseNumber := func() error {
 		number++
@@ -40,7 +40,7 @@ func ExampleRetryDuration() {
 		return errors.New("error occurs")
 	}
 
-	err := Retry(increaseNumber, RetryDuration(time.Microsecond*50))
+	err := Retry(increaseNumber, RetryWithLinearBackoff(time.Microsecond*50))
 	if err != nil {
 		return
 	}
@@ -81,7 +81,7 @@ func ExampleRetry() {
 		return errors.New("error occurs")
 	}
 
-	err := Retry(increaseNumber, RetryDuration(time.Microsecond*50))
+	err := Retry(increaseNumber, RetryWithLinearBackoff(time.Microsecond*50))
 	if err != nil {
 		return
 	}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -20,7 +20,7 @@ func TestRetryFailed(t *testing.T) {
 		return errors.New("error occurs")
 	}
 
-	err := Retry(increaseNumber, RetryDuration(time.Microsecond*50))
+	err := Retry(increaseNumber, RetryWithLinearBackoff(time.Microsecond*50))
 
 	assert.IsNotNil(err)
 	assert.Equal(DefaultRetryTimes, number)
@@ -40,7 +40,7 @@ func TestRetrySucceeded(t *testing.T) {
 		return errors.New("error occurs")
 	}
 
-	err := Retry(increaseNumber, RetryDuration(time.Microsecond*50))
+	err := Retry(increaseNumber, RetryWithLinearBackoff(time.Microsecond*50))
 
 	assert.IsNil(err)
 	assert.Equal(DefaultRetryTimes, number)
@@ -57,7 +57,7 @@ func TestSetRetryTimes(t *testing.T) {
 		return errors.New("error occurs")
 	}
 
-	err := Retry(increaseNumber, RetryDuration(time.Microsecond*50), RetryTimes(3))
+	err := Retry(increaseNumber, RetryWithLinearBackoff(time.Microsecond*50), RetryTimes(3))
 
 	assert.IsNotNil(err)
 	assert.Equal(3, number)
@@ -79,7 +79,7 @@ func TestCancelRetry(t *testing.T) {
 	}
 
 	err := Retry(increaseNumber,
-		RetryDuration(time.Microsecond*50),
+		RetryWithLinearBackoff(time.Microsecond*50),
 		Context(ctx),
 	)
 


### PR DESCRIPTION
The aim of this policy is to enable the configuration of various types of backoff mathematical curves. Should this modification be deemed suitable, I will proceed to implement an exponential curve backoff policy and set of custom backoff policy 

**Warning: It's major break**