### PR TITLE
Add custom backoff setter

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -44,6 +44,18 @@ func RetryTimes(n uint) Option {
 	}
 }
 
+// RetryWithCustomBackoff set abitary custom backoff strategy
+// todo: Add playground link
+func RetryWithCustomBackoff(backoffStrategy BackoffStrategy) Option {
+	if backoffStrategy == nil {
+		panic("programming error: backoffStrategy must be not nil")
+	}
+
+	return func(rc *RetryConfig) {
+		rc.backoffStrategy = backoffStrategy
+	}
+}
+
 // RetryWithLinearBackoff set linear strategy backoff
 // todo: Add playground link
 func RetryWithLinearBackoff(interval time.Duration) Option {

--- a/retry/retry_example_test.go
+++ b/retry/retry_example_test.go
@@ -51,6 +51,35 @@ func ExampleRetryWithLinearBackoff() {
 	// 3
 }
 
+type ExampleCustomBackoffStrategy struct {
+	interval time.Duration
+}
+
+func (c *ExampleCustomBackoffStrategy) CalculateInterval() time.Duration {
+	return c.interval + 1
+}
+
+func ExampleRetryWithCustomBackoff() {
+	number := 0
+	increaseNumber := func() error {
+		number++
+		if number == 3 {
+			return nil
+		}
+		return errors.New("error occurs")
+	}
+
+	err := Retry(increaseNumber, RetryWithCustomBackoff(&ExampleCustomBackoffStrategy{interval: time.Microsecond * 50}))
+	if err != nil {
+		return
+	}
+
+	fmt.Println(number)
+
+	// Output:
+	// 3
+}
+
 func ExampleRetryWithExponentialWithJitterBackoff() {
 	number := 0
 	increaseNumber := func() error {

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -137,6 +137,34 @@ func TestRetryOneShotSucceeded(t *testing.T) {
 	assert.Equal(1, number)
 }
 
+func TestRetryWitCustomBackoffOneShotSucceeded(t *testing.T) {
+	t.Parallel()
+
+	assert := internal.NewAssert(t, "TestRetryWitCustomBackoffOneShotSucceeded")
+
+	var number int
+	increaseNumber := func() error {
+		number++
+		if number == DefaultRetryTimes {
+			return nil
+		}
+		return errors.New("error occurs")
+	}
+
+	err := Retry(increaseNumber, RetryWithCustomBackoff(&TestCustomBackoffStrategy{interval: time.Microsecond * 50}))
+
+	assert.IsNil(err)
+	assert.Equal(5, number)
+}
+
+type TestCustomBackoffStrategy struct {
+	interval time.Duration
+}
+
+func (c *TestCustomBackoffStrategy) CalculateInterval() time.Duration {
+	return c.interval + 1
+}
+
 func TestRetryWithExponentialWithJitterBackoffShiftOneShotSucceeded(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Users should have the capability to customize the backoff pattern and accordingly adjust it within the retry mechanism.

@duke-git Have a look please