### PR TITLE
CopyOnWriteList add IndexOfFunc and LastIndexOfFunc

### DIFF
--- a/datastructure/list/copyonwritelist.go
+++ b/datastructure/list/copyonwritelist.go
@@ -90,6 +90,35 @@ func lastIndexOf[T any](o T, e []T, start int, end int) int {
 	return -1
 }
 
+// LastIndexOfFunc returns the index of the last occurrence of the value in this list satisfying the
+// functional predicate f(T) bool
+// if not found return -1.
+func (l *CopyOnWriteList[T]) LastIndexOfFunc(f func(T) bool) int {
+	index := -1
+	data := l.getList()
+	for i := len(data) - 1; i >= 0; i-- {
+		if f(data[i]) {
+			index = i
+			break
+		}
+	}
+	return index
+}
+
+// IndexOfFunc returns the first index satisfying the functional predicate f(v) bool
+// if not found return -1.
+func (l *CopyOnWriteList[T]) IndexOfFunc(f func(T) bool) int {
+	index := -1
+	data := l.getList()
+	for i, v := range data {
+		if f(v) {
+			index = i
+			break
+		}
+	}
+	return index
+}
+
 // get returns the element at the specified position in this list.
 func get[T any](o []T, index int) *T {
 	return &o[index]

--- a/datastructure/list/copyonwritelist_test.go
+++ b/datastructure/list/copyonwritelist_test.go
@@ -1,8 +1,9 @@
 package datastructure
 
 import (
-	"github.com/duke-git/lancet/v2/internal"
 	"testing"
+
+	"github.com/duke-git/lancet/v2/internal"
 )
 
 func TestCopyOnWriteList_ValueOf(t *testing.T) {
@@ -232,4 +233,36 @@ func TestCopyOnWriteList_SubList(t *testing.T) {
 	list = NewCopyOnWriteList([]int{1, 3, 5, 7, 9, 2, 4, 6, 8, 10})
 	subList = list.SubList(11, 1)
 	assert.Equal([]int{}, subList)
+}
+
+func TestCopyOnWriteListIndexOfFunc(t *testing.T) {
+	t.Parallel()
+
+	assert := internal.NewAssert(t, "TestIndexOfFunc")
+
+	list := NewCopyOnWriteList([]int{1, 2, 3})
+	i := list.IndexOfFunc(func(a int) bool { return a == 1 })
+	assert.Equal(0, i)
+
+	i = list.IndexOfFunc(func(a int) bool { return a == 4 })
+	assert.Equal(-1, i)
+}
+
+func TestNewCopyOnWriteListLastIndexOfFunc(t *testing.T) {
+	t.Parallel()
+
+	assert := internal.NewAssert(t, "TestLastIndexOfFunc")
+
+	list := NewCopyOnWriteList([]int{1, 2, 3, 3, 3, 3, 4, 5, 6, 9})
+	i := list.LastIndexOfFunc(func(a int) bool { return a == 3 })
+	assert.Equal(5, i)
+
+	i = list.LastIndexOfFunc(func(a int) bool { return a == 10 })
+	assert.Equal(-1, i)
+
+	i = list.LastIndexOfFunc(func(a int) bool { return a == 4 })
+	assert.Equal(6, i)
+
+	i = list.LastIndexOfFunc(func(a int) bool { return a == 1 })
+	assert.Equal(0, i)
 }

--- a/docs/api/packages/datastructure/copyonwritelist.md
+++ b/docs/api/packages/datastructure/copyonwritelist.md
@@ -26,6 +26,8 @@ import (
 -   [Remove](#Remove)
 -   [IndexOf](#IndexOf)
 -   [LastIndexOf](#LastIndexOf)
+-   [IndexOfFunc](#IndexOfFunc)
+-   [LastIndexOfFunc](#LastIndexOfFunc)
 -   [IsEmpty](#IsEmpty)
 -   [Contain](#Contain)
 -   [ValueOf](#ValueOf)
@@ -196,6 +198,58 @@ func main()  {
 	fmt.Println(l.LastIndexOf(1))
 }
 
+```
+
+### <span id="IndexOfFunc">IndexOfFunc</span>
+<p>返回第一个符合函数条件的元素的索引。如果未找到，则返回-1</p>
+
+<b>函数签名:</b>
+
+```go
+func (l *CopyOnWriteList[T]) IndexOfFunc(f func(T) bool) int 
+```
+<b>示例:</b>
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/duke-git/lancet/v2/datastructure/list"
+)
+
+func main() {
+    l := list.NewCopyOnWriteList([]int{1, 2, 3})
+
+    fmt.Println(l.IndexOfFunc(func(a int) bool { return a == 1 })) //0
+    fmt.Println(l.IndexOfFunc(func(a int) bool { return a == 0 })) //-1
+}
+```
+
+### <span id="LastIndexOfFunc">LastIndexOfFunc</span>
+<p>返回最后一个符合函数条件的元素的索引。如果未找到，则返回-1</p>
+
+<b>函数签名:</b>
+
+```go
+func (l *CopyOnWriteList[T]) LastIndexOfFunc(f func(T) bool) int
+```
+<b>示例:</b>
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/duke-git/lancet/v2/datastructure/list"
+)
+
+func main() {
+    l := list.NewCopyOnWriteList([]int{1, 2, 3, 1})
+
+    fmt.Println(l.LastIndexOfFunc(func(a int) bool { return a == 1 })) // 3
+    fmt.Println(l.LastIndexOfFunc(func(a int) bool { return a == 0 })) //-1
+}
 ```
 
 ### IsEmpty

--- a/docs/en/api/packages/datastructure/copyonwritelist.md
+++ b/docs/en/api/packages/datastructure/copyonwritelist.md
@@ -26,6 +26,8 @@ import (
 -   [Remove](#Remove)
 -   [IndexOf](#IndexOf)
 -   [LastIndexOf](#LastIndexOf)
+-   [IndexOfFunc](#IndexOfFunc)
+-   [LastIndexOfFunc](#LastIndexOfFunc)
 -   [IsEmpty](#IsEmpty)
 -   [Contain](#Contain)
 -   [ValueOf](#ValueOf)
@@ -195,6 +197,59 @@ func main() {
     fmt.Println(l.LastIndexOf(1))
 }
 
+```
+
+
+### <span id="IndexOfFunc">IndexOfFunc</span>
+<p> IndexOfFunc returns the first index satisfying the functional predicate f(v) bool. if not found return -1.</p>
+
+<b>Signature:</b>
+
+```go
+func (l *CopyOnWriteList[T]) IndexOfFunc(f func(T) bool) int 
+```
+<b>Example:</b>
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/duke-git/lancet/v2/datastructure/list"
+)
+
+func main() {
+    l := list.NewCopyOnWriteList([]int{1, 2, 3})
+
+    fmt.Println(l.IndexOfFunc(func(a int) bool { return a == 1 })) //0
+    fmt.Println(l.IndexOfFunc(func(a int) bool { return a == 0 })) //-1
+}
+```
+
+### <span id="LastIndexOfFunc">LastIndexOfFunc</span>
+<p>LastIndexOfFunc returns the index of the last occurrence of the value in this list satisfying the functional predicate f(T) bool. if not found return -1.</p>
+
+<b>Signature:</b>
+
+```go
+func (l *CopyOnWriteList[T]) LastIndexOfFunc(f func(T) bool) int
+```
+<b>Example:</b>
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/duke-git/lancet/v2/datastructure/list"
+)
+
+func main() {
+    l := list.NewCopyOnWriteList([]int{1, 2, 3, 1})
+
+    fmt.Println(l.LastIndexOfFunc(func(a int) bool { return a == 1 })) // 3
+    fmt.Println(l.LastIndexOfFunc(func(a int) bool { return a == 0 })) //-1
+}
 ```
 
 ### IsEmpty


### PR DESCRIPTION
Allow users to apply functional predicates alongside 'index of' and 'last index of' search methods in this specialized list variant

Note: I am not fluent in Chinese; the Chinese document may require a revisions.