### PR TITLE
round related method support generics

### DIFF
--- a/docs/api/packages/mathutil.md
+++ b/docs/api/packages/mathutil.md
@@ -392,7 +392,7 @@ func main() {
 <b>函数签名:</b>
 
 ```go
-func RoundToFloat(x float64, n int) float64
+func RoundToFloat[T constraints.Float | constraints.Integer](x T, n int) float64
 ```
 
 <b>示例:<span style="float:right;display:inline-block;">[运行](https://go.dev/play/p/ghyb528JRJL)</span></b>
@@ -428,7 +428,7 @@ func main() {
 <b>函数签名:</b>
 
 ```go
-func RoundToString(x float64, n int) string
+func RoundToString[T constraints.Float | constraints.Integer](x T, n int) string
 ```
 
 <b>示例:<span style="float:right;display:inline-block;">[运行](https://go.dev/play/p/kZwpBRAcllO)</span></b>
@@ -464,7 +464,7 @@ func main() {
 <b>函数签名:</b>
 
 ```go
-func TruncRound(x float64, n int) float64
+func TruncRound[T constraints.Float | constraints.Integer](x T, n int) T 
 ```
 
 <b>示例:<span style="float:right;display:inline-block;">[运行](https://go.dev/play/p/aumarSHIGzP)</span></b>

--- a/docs/en/api/packages/mathutil.md
+++ b/docs/en/api/packages/mathutil.md
@@ -392,7 +392,7 @@ func main() {
 <b>Signature:</b>
 
 ```go
-func RoundToFloat(x float64, n int) float64
+func RoundToFloat[T constraints.Float | constraints.Integer](x T, n int) float64
 ```
 
 <b>Example:<span style="float:right;display:inline-block;">[Run](https://go.dev/play/p/ghyb528JRJL)</span></b>
@@ -428,7 +428,7 @@ func main() {
 <b>Signature:</b>
 
 ```go
-func RoundToString(x float64, n int) string
+func RoundToString[T constraints.Float | constraints.Integer](x T, n int) string
 ```
 
 <b>Example:<span style="float:right;display:inline-block;">[Run](https://go.dev/play/p/kZwpBRAcllO)</span></b>
@@ -464,7 +464,7 @@ func main() {
 <b>Signature:</b>
 
 ```go
-func TruncRound(x float64, n int) float64
+func TruncRound[T constraints.Float | constraints.Integer](x T, n int) T 
 ```
 
 <b>Example:<span style="float:right;display:inline-block;">[Run](https://go.dev/play/p/aumarSHIGzP)</span></b>

--- a/mathutil/mathutil.go
+++ b/mathutil/mathutil.go
@@ -68,26 +68,26 @@ func Percent(val, total float64, n int) float64 {
 
 // RoundToString round up to n decimal places.
 // Play: https://go.dev/play/p/kZwpBRAcllO
-func RoundToString(x float64, n int) string {
+func RoundToString[T constraints.Float | constraints.Integer](x T, n int) string {
 	tmp := math.Pow(10.0, float64(n))
-	x *= tmp
-	x = math.Round(x)
-	result := strconv.FormatFloat(x/tmp, 'f', n, 64)
+	x *= T(tmp)
+	r := math.Round(float64(x))
+	result := strconv.FormatFloat(r/tmp, 'f', n, 64)
 	return result
 }
 
 // RoundToFloat round up to n decimal places.
 // Play: https://go.dev/play/p/ghyb528JRJL
-func RoundToFloat(x float64, n int) float64 {
+func RoundToFloat[T constraints.Float | constraints.Integer](x T, n int) float64 {
 	tmp := math.Pow(10.0, float64(n))
-	x *= tmp
-	x = math.Round(x)
-	return x / tmp
+	x *= T(tmp)
+	r := math.Round(float64(x))
+	return r / tmp
 }
 
 // TruncRound round off n decimal places.
 // Play: https://go.dev/play/p/aumarSHIGzP
-func TruncRound(x float64, n int) float64 {
+func TruncRound[T constraints.Float | constraints.Integer](x T, n int) T {
 	floatStr := fmt.Sprintf("%."+strconv.Itoa(n+1)+"f", x)
 	temp := strings.Split(floatStr, ".")
 	var newFloat string
@@ -97,7 +97,7 @@ func TruncRound(x float64, n int) float64 {
 		newFloat = temp[0] + "." + temp[1][:n]
 	}
 	result, _ := strconv.ParseFloat(newFloat, 64)
-	return result
+	return T(result)
 }
 
 // Max return max value of numbers.

--- a/mathutil/mathutil_test.go
+++ b/mathutil/mathutil_test.go
@@ -72,6 +72,8 @@ func TestRoundToString(t *testing.T) {
 	assert.Equal("0.12", RoundToString(0.124, 2))
 	assert.Equal("0.13", RoundToString(0.125, 2))
 	assert.Equal("0.125", RoundToString(0.125, 3))
+	//assert.Equal("54.321", RoundToString(54.321, 3))
+	//assert.Equal("17.000", RoundToString(17, 3))
 }
 
 func TestTruncRound(t *testing.T) {
@@ -79,8 +81,12 @@ func TestTruncRound(t *testing.T) {
 
 	assert := internal.NewAssert(t, "TestTruncRound")
 
-	assert.Equal(float64(0), TruncRound(0, 0))
-	assert.Equal(float64(0), TruncRound(0, 1))
+	assert.Equal(float64(0), TruncRound(float64(0), 0))
+	assert.Equal(float64(0), TruncRound(float64(0), 1))
+	assert.Equal(float32(0), TruncRound(float32(0), 0))
+	assert.Equal(float32(0), TruncRound(float32(0), 1))
+	assert.Equal(0, TruncRound(0, 0))
+	assert.Equal(uint64(0), TruncRound(uint64(0), 1))
 	assert.Equal(0.12, TruncRound(0.124, 2))
 	assert.Equal(0.12, TruncRound(0.125, 2))
 	assert.Equal(0.125, TruncRound(0.125, 3))


### PR DESCRIPTION
The range of supported types refers to [Round[T SignedNumber | UnsignedNumber](val T) T](https://github.com/tiny-craft/tiny-rdm/blob/main/backend/utils/math/math_util.go#L67)

Regarding the TruncRound method, it fails the original test when x is the literal 0, which is a refactoring that breaks compatibility. However, I believe few people would do this. 

Personally, I think it makes more intuitive sense for the parameter and return types to be consistent, while the semantics of the original function names are preserved for other functions.
