### PR TITLE
fix(netutil): Add proxy IP to send request

### DIFF
--- a/netutil/http.go
+++ b/netutil/http.go
@@ -109,6 +109,7 @@ type HttpClientConfig struct {
 	HandshakeTimeout time.Duration
 	ResponseTimeout  time.Duration
 	Verbose          bool
+	Proxy            *url.URL
 }
 
 // defaultHttpClientConfig defalut client config.
@@ -162,6 +163,11 @@ func NewHttpClientWithConfig(config *HttpClientConfig) *HttpClient {
 
 	if config.SSLEnabled {
 		client.TLS = config.TLSConfig
+	}
+
+	if config.Proxy != nil {
+		transport := client.Client.Transport.(*http.Transport)
+		transport.Proxy = http.ProxyURL(config.Proxy)
 	}
 
 	return client

--- a/netutil/http_test.go
+++ b/netutil/http_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/duke-git/lancet/v2/internal"
 )
@@ -357,6 +358,25 @@ func TestSendRequestWithFilePath(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+}
+
+func TestProxy(t *testing.T) {
+	config := &HttpClientConfig{
+		HandshakeTimeout: 20 * time.Second,
+		ResponseTimeout:  40 * time.Second,
+		Proxy: &url.URL{
+			Scheme: "http",
+			Host:   "46.17.63.166:18888",
+		},
+	}
+	httpClient := NewHttpClientWithConfig(config)
+	resp, err := httpClient.Get("https://www.ipplus360.com/getLocation")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected %d, got %d", http.StatusOK, resp.StatusCode)
 	}

--- a/netutil/http_test.go
+++ b/netutil/http_test.go
@@ -367,10 +367,11 @@ func TestProxy(t *testing.T) {
 	config := &HttpClientConfig{
 		HandshakeTimeout: 20 * time.Second,
 		ResponseTimeout:  40 * time.Second,
-		Proxy: &url.URL{
-			Scheme: "http",
-			Host:   "46.17.63.166:18888",
-		},
+		// Use the proxy ip to add it here
+		//Proxy: &url.URL{
+		//	Scheme: "http",
+		//	Host:   "46.17.63.166:18888",
+		//},
 	}
 	httpClient := NewHttpClientWithConfig(config)
 	resp, err := httpClient.Get("https://www.ipplus360.com/getLocation")


### PR DESCRIPTION
Add the Proxy parameter in HttpClientConfig struct to conveniently use the proxy IP to send requests.