### PR TITLE
refactor slice.Unique()

### DIFF
--- a/slice/slice.go
+++ b/slice/slice.go
@@ -772,21 +772,14 @@ func UpdateAt[T any](slice []T, index int, value T) []T {
 // Play: https://go.dev/play/p/AXw0R3ZTE6a
 func Unique[T comparable](slice []T) []T {
 	result := []T{}
-
-	for i := 0; i < len(slice); i++ {
-		v := slice[i]
-		skip := true
-		for j := range result {
-			if v == result[j] {
-				skip = false
-				break
-			}
+	exists := map[T]bool{}
+	for _, t := range slice {
+		if exists[t] {
+			continue
 		}
-		if skip {
-			result = append(result, v)
-		}
+		exists[t] = true
+		result = append(result, t)
 	}
-
 	return result
 }
 


### PR DESCRIPTION
优化slice.Unique()方法,使性能提高20倍以上.

对10万个随机切片进行去重:
原方法:
```
goos: linux
goarch: amd64
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkUnique
BenchmarkUnique-8   	1000000000	         0.1229 ns/op
PASS
```
优化后的方法:
```
goos: linux
goarch: amd64
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkUnique2
BenchmarkUnique2-8   	1000000000	         0.004338 ns/op
PASS
```
使用的随机切片如下:
```
func GetS (length int) []int {
	rand.Seed(time.Now().UnixNano())
	slice := make([]int, length)
	for i := 0; i < length; i++ {
		slice[i] = rand.Intn(10000)
	}
	return slice
}
```