### PR TITLE
fix:convertor struct to map by struct ptr

### DIFF
--- a/convertor/convertor.go
+++ b/convertor/convertor.go
@@ -197,6 +197,7 @@ func StructToMap(value interface{}) (map[string]interface{}, error) {
 
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
+		v = v.Elem()
 	}
 	if t.Kind() != reflect.Struct {
 		return nil, fmt.Errorf("data type %T not support, shuld be struct or pointer to struct", value)

--- a/convertor/convertor_test.go
+++ b/convertor/convertor_test.go
@@ -156,13 +156,17 @@ func TestStructToMap(t *testing.T) {
 		Name string `json:"name"`
 		age  int
 	}
-	p := People{
+	p := &People{
 		"test",
 		100,
 	}
 	pm, _ := StructToMap(p)
-	var expected = map[string]interface{}{"name": "test"}
+	data, _ := StructToMap(p)
+	var expected = map[string]interface{}{
+		"name": "test",
+	}
 	assert.Equal(expected, pm)
+	assert.Equal(expected, data)
 }
 
 func TestColorHexToRGB(t *testing.T) {


### PR DESCRIPTION
将structtomap的方式 如果传递指针进来做参数会导致panic ，修复可允许传递指针