### PR TITLE
perf(slice): Concat() make a clearer panic description, like standard library

### DIFF
--- a/docs/api/packages/slice.md
+++ b/docs/api/packages/slice.md
@@ -322,12 +322,12 @@ func main() {
 
 ### <span id="Concat">Concat</span>
 
-<p>合并多个slices到slice中</p>
+<p>创建一个新的切片，将传入的切片拼接起来返回。</p>
 
 <b>函数签名:</b>
 
 ```go
-func Concat[T any](slice []T, slices ...[]T) []T
+func Concat[T any](slices ...[]T) []T
 ```
 
 <b>示例:<span style="float:right;display:inline-block;">[运行](https://go.dev/play/p/gPt-q7zr5mk)</span></b>
@@ -1542,7 +1542,7 @@ func main() {
 }
 ```
 
-### <span id="Merge">Merge</span>
+### <span id="Merge">Merge（废弃：使用Concat）</span>
 
 <p>合并多个切片（不会消除重复元素).</p>
 

--- a/docs/en/api/packages/slice.md
+++ b/docs/en/api/packages/slice.md
@@ -321,12 +321,12 @@ func main() {
 
 ### <span id="Concat">Concat</span>
 
-<p>Creates a new slice concatenating slice with any additional slices.</p>
+<p>Concat creates a new slice concatenating slice with any additional slices.</p>
 
 <b>Signature:</b>
 
 ```go
-func Concat[T any](slice []T, slices ...[]T) []T
+func Concat[T any](slices ...[]T) []T
 ```
 
 <b>Example:<span style="float:right;display:inline-block;">[Run](https://go.dev/play/p/gPt-q7zr5mk)</span></b>
@@ -1540,7 +1540,7 @@ func main() {
 }
 ```
 
-### <span id="Merge">Merge</span>
+### <span id="Merge">Merge(deprecated: use Concat)</span>
 
 <p>Merge all given slices into one slice.</p>
 

--- a/slice/slice.go
+++ b/slice/slice.go
@@ -109,18 +109,18 @@ func Compact[T comparable](slice []T) []T {
 
 // Concat creates a new slice concatenating slice with any additional slices.
 // Play: https://go.dev/play/p/gPt-q7zr5mk
-func Concat[T any](slice []T, slices ...[]T) []T {
-	totalLen := len(slice)
-
+func Concat[T any](slices ...[]T) []T {
+	totalLen := 0
 	for _, v := range slices {
 		totalLen += len(v)
+		if totalLen < 0 {
+			panic("len out of range")
+		}
 	}
-
 	result := make([]T, 0, totalLen)
 
-	result = append(result, slice...)
-	for _, s := range slices {
-		result = append(result, s...)
+	for _, v := range slices {
+		result = append(result, v...)
 	}
 
 	return result
@@ -833,20 +833,11 @@ func UnionBy[T any, V comparable](predicate func(item T) V, slices ...[]T) []T {
 	return result
 }
 
+// Deprecated:  Please use Concat() function instead.
 // Merge all given slices into one slice.
 // Play: https://go.dev/play/p/lbjFp784r9N
 func Merge[T any](slices ...[]T) []T {
-	totalLen := 0
-	for _, v := range slices {
-		totalLen += len(v)
-	}
-	result := make([]T, 0, totalLen)
-
-	for _, v := range slices {
-		result = append(result, v...)
-	}
-
-	return result
+	return Concat(slices...)
 }
 
 // Intersection creates a slice of unique elements that included by all slices.


### PR DESCRIPTION
https://github.com/golang/go/blob/master/src/slices/slices.go#L476 

Deprecate functions with the same functionality.