### PR TITLE
fix(strutil): rename PadStart to Pad.

### DIFF
--- a/strutil/string.go
+++ b/strutil/string.go
@@ -75,7 +75,7 @@ func LowerFirst(s string) string {
 	return string(r) + s[size:]
 }
 
-// PadStart pads string on the left and right side if it's shorter than size.
+// Pad pads string on the left and right side if it's shorter than size.
 // Padding characters are truncated if they exceed size.
 // Play: https://go.dev/play/p/NzImQq-VF8q
 func Pad(source string, size int, padStr string) string {


### PR DESCRIPTION
In the strutil/string.go file, the function comment for ‘Pad’ is wrong. It should be Pad instead of PadStart.