### PR TITLE
fix: fix compile error when go sdk version below go@1.20 (#255)

### DIFF
--- a/slice/slice_concurrent.go
+++ b/slice/slice_concurrent.go
@@ -195,18 +195,14 @@ func UniqueByConcurrent[T comparable](slice []T, comparator func(item T, other T
 		chunks = append(chunks, slice[i:end])
 	}
 
-	type resultChunk struct {
-		index int
-		data  []T
-	}
-	resultCh := make(chan resultChunk, numThreads)
+	resultCh := make(chan resultChunk[T], numThreads)
 	var wg sync.WaitGroup
 
 	for i, chunk := range chunks {
 		wg.Add(1)
 		go func(index int, chunk []T) {
 			defer wg.Done()
-			resultCh <- resultChunk{index, removeDuplicate(chunk, comparator)}
+			resultCh <- resultChunk[T]{index, removeDuplicate(chunk, comparator)}
 		}(i, chunk)
 	}
 

--- a/slice/slice_internal.go
+++ b/slice/slice_internal.go
@@ -7,6 +7,13 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+// resultChunk is used to store the intermediate results of UniqueByConcurrent.
+// It is defined separately to be compatible with versions of go up to 1.20.
+type resultChunk[T comparable] struct {
+	index int
+	data  []T
+}
+
 // sliceValue return the reflect value of a slice
 func sliceValue(slice any) reflect.Value {
 	v := reflect.ValueOf(slice)


### PR DESCRIPTION
修复#255中描述的`type declarations inside generic functions are not currently supported`在go@1.18.x中的编译异常，实际上泛型函数内类型定义在1.20以后的版本才支持。
另外，可以考虑github action中将go版本调整为`1.18.10`避免未来再出现兼容性异常