### PR TITLE
fix: fix slice_test.go ,We should not assume the order of the slice

### DIFF
--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1794,6 +1795,8 @@ func TestFilterConcurrent(t *testing.T) {
 		nums := []int{1, 2, 3, 4, 5, 6}
 		expected := []int{4, 5, 6}
 		actual := FilterConcurrent(nums, func(_, n int) bool { return n > 3 }, 4)
+		sort.Ints(actual)
+		sort.Ints(expected)
 		assert.Equal(expected, actual)
 	})
 }


### PR DESCRIPTION
在slice/slice_test.go这个文件中，使用多个goroutine测试FilterConcurrent函数，在对返回的slice进行比较的时候，应该先进行排序，否则比较结果会出现概率性错误