### PR TITLE
fix(package): [slice] Fix RigthPadding and LeftPadding

### DIFF
--- a/slice/slice.go
+++ b/slice/slice.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	stdslices "slices"
 
 	"github.com/duke-git/lancet/v2/random"
 	"golang.org/x/exp/constraints"
@@ -1472,9 +1471,9 @@ func Random[T any](slice []T) (val T, idx int) {
 func RightPadding[T any](slice []T, paddingValue T, paddingLength int) []T {
 	suffix := []T{}
 	if paddingLength > 0 {
-		suffix = stdslices.Repeat([]T{paddingValue}, paddingLength)
+		suffix = repeat([]T{paddingValue}, paddingLength)
 	}
-	padded := stdslices.Concat(slice, suffix)
+	padded := concat(slice, suffix)
 	return padded
 }
 
@@ -1484,9 +1483,9 @@ func RightPadding[T any](slice []T, paddingValue T, paddingLength int) []T {
 func LeftPadding[T any](slice []T, paddingValue T, paddingLength int) []T {
 	prefix := []T{}
 	if paddingLength > 0 {
-		prefix = stdslices.Repeat([]T{paddingValue}, paddingLength)
+		prefix = repeat([]T{paddingValue}, paddingLength)
 	}
-	padded := stdslices.Concat(prefix, slice)
+	padded := concat(prefix, slice)
 	return padded
 }
 

--- a/slice/slice.go
+++ b/slice/slice.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	stdslices "slices"
 
 	"github.com/duke-git/lancet/v2/random"
 	"golang.org/x/exp/constraints"
@@ -1465,36 +1466,28 @@ func Random[T any](slice []T) (val T, idx int) {
 	return slice[idx], idx
 }
 
-// RightPadding adds padding to the right end of a slice.
+// RightPadding returns a copy of the slice padding the given value to the right end of a slice.
+// If paddingLength is zero or less, the function returns a copy of the slice.
 // Play: https://go.dev/play/p/0_2rlLEMBXL
 func RightPadding[T any](slice []T, paddingValue T, paddingLength int) []T {
-	if paddingLength == 0 {
-		return slice
+	suffix := []T{}
+	if paddingLength > 0 {
+		suffix = stdslices.Repeat([]T{paddingValue}, paddingLength)
 	}
-	for i := 0; i < paddingLength; i++ {
-		slice = append(slice, paddingValue)
-	}
-	return slice
+	padded := stdslices.Concat(slice, suffix)
+	return padded
 }
 
-// LeftPadding adds padding to the left begin of a slice.
+// LeftPadding returns a copy of the slice padding the given value to the left begin of a slice.
+// If paddingLength is zero or less, the function returns a copy of the slice.
 // Play: https://go.dev/play/p/jlQVoelLl2k
 func LeftPadding[T any](slice []T, paddingValue T, paddingLength int) []T {
-	if paddingLength == 0 {
-		return slice
+	prefix := []T{}
+	if paddingLength > 0 {
+		prefix = stdslices.Repeat([]T{paddingValue}, paddingLength)
 	}
-
-	paddedSlice := make([]T, len(slice)+paddingLength)
-	i := 0
-	for ; i < paddingLength; i++ {
-		paddedSlice[i] = paddingValue
-	}
-	for j := 0; j < len(slice); j++ {
-		paddedSlice[i] = slice[j]
-		i++
-	}
-
-	return paddedSlice
+	padded := stdslices.Concat(prefix, slice)
+	return padded
 }
 
 // Frequency counts the frequency of each element in the slice.

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -1756,6 +1756,20 @@ func TestRightPaddingAndLeftPadding(t *testing.T) {
 
 	padded := LeftPadding(RightPadding(nums, 0, 3), 0, 3)
 	assert.Equal([]int{0, 0, 0, 1, 2, 3, 4, 5, 0, 0, 0}, padded)
+
+	// Test with negative padding length
+	paddedNegative := LeftPadding(RightPadding(nums, 0, -3), 0, -3)
+	assert.Equal([]int{1, 2, 3, 4, 5}, paddedNegative)
+
+	// Test with empty slice
+	empty := []int{}
+	paddedEmpty := LeftPadding(RightPadding(empty, 0, 3), 0, 3)
+	assert.Equal([]int{0, 0, 0, 0, 0, 0}, paddedEmpty)
+
+	// Test with nil
+	nilSlice := []int(nil)
+	paddedNil := LeftPadding(RightPadding(nilSlice, 0, 3), 0, 3)
+	assert.Equal([]int{0, 0, 0, 0, 0, 0}, paddedNil)
 }
 
 func TestUniqueByConcurrent(t *testing.T) {


### PR DESCRIPTION
The `RightPadding` and `LeftPadding` functions in the `slice` package have some issues.  Also discussed in issue(#320 ):

1.  `RightPadding` modifies the given slice in place, while  `LeftPadding` returns a copy of the slice with the padding (or the given slice if the paddingLenght is 0).  That is not consistent, and brings problems to the caller as it behaves different depending on the situation.
2. Both functions cannot deal with paddingLength negative values.

This can be shown by running the following code (or in Play https://go.dev/play/p/y7G86ZQjJBP):

```go
// You can edit this code!
// Click here and start typing.
package main

import (
	"fmt"

	"github.com/duke-git/lancet/v2/slice"
)

func main() {
	nums := []int{1, 2, 3, 4, 5}
	padded := slice.LeftPadding(nums, 0, 3)
	fmt.Println(padded)
	// Output:
	// [0 0 0 1 2 3 4 5]

	// This code has some issues:

	// 1. It returns a new slice if padding lenght is greater than 0 (see above), but the given slice if padding lenght is 0
	paddedWithNothing := slice.LeftPadding(nums, 0, 0)
	paddedWithNothing[0] = 10
	fmt.Println(nums) // Nums modified !
	fmt.Println(paddedWithNothing)

	// 2. Cannot deal with negative padding lenght
	paddedWithNegative := slice.LeftPadding(nums, 0, -3)  \\ <== Fails
	fmt.Println(paddedWithNegative)
}
```

This PR solves:

a.  these two issues, 
b. modernizes the code, 
c. and includes additional tests for padding with negative length, padding empty slices, and padding nil slices.

## The catch! 

The proposed code __uses the standard lib "slices" package for creating the padding suffix/prefix and concatenating the slices__.    The dependency to the standard lib is already present in the lancet module, BUT was not present in the `slice` package.

I propose we accept this dependency.  Since Go1.21 the "slices" package was made official and has many potentials to modernize parts of the current lancet code base.  It can be used also to improve other functions (later).

@duke-git , If you think this dependency is not desired, I can re-write the code to mimic it.  My point is that some of the functionality on the std lib can be used (also on other functions) to make it safer, more consistent, and similar behavior on corner cases (e.g. dealing with empty slices).  The dependency of lancet to the std lib is already accepted and documented.