### PR TITLE
fix(package): [slice] functions with inconsistent return behaviour

### DIFF
--- a/slice/slice.go
+++ b/slice/slice.go
@@ -1076,7 +1076,7 @@ func Shuffle[T any](slice []T) []T {
 	rand.Seed(time.Now().UnixNano())
 
 	rand.Shuffle(len(slice), func(i, j int) {
-		slice[i], slice[j] = slice[j], slice[i]
+		swap(slice, i, j)
 	})
 
 	return slice


### PR DESCRIPTION
Hi Duke and all Lancet enthusiasts,

The following functions in the `slice` package have inconsistent behaviour in
its return value:

* `DeleteAt`
* `Drop`
* `DropRight`
* `InsertAt`
* `UpdateAt`
* `Without`


These functions return __the same__ slice passed as input (in place modification) on
some conditions, and __a copy__ of the input slice (no in place modification) on other
conditions.  I use the `DeleteAt` function as an example:

```go
func DeleteAt[T any](slice []T, index int) []T {
	if index < 0 || index >= len(slice) {
		return slice[:len(slice)-1]
	}

	result := append([]T(nil), slice...)
	copy(result[index:], result[index+1:])

	// Set the last element to zero value, clean up the memory.
	result[len(result)-1] = zeroValue[T]()

	return result[:len(result)-1]
}
```

Note that in case the slice is empty or the deletion index is negative, the return value
is the same passed slice.  In this case, there is no modification of the passed input.
But if the code proceeds further, it will return a copy of the passed input.

This return/modification behaviour can be a source of confusion, as sometimes the user
will receive a copy, and sometimes the same passed slice.

This fix goes over all the mentioned functions above and corrects them __for this
inconsistent behaviour__.  The correction is applied in such form that a __copy__ of the
passed slice is returned -- never a modified version of the passed slice.

Other remarks:

0) Note that if a function modifies and returns the given slice in place for all cases;
   or it returns a modified copy for all cases.  There is no fix.  I consider this is
   the desired functionality of the function. 
1) The functions `Unique`, `UniqueBy`, `UniqueByComparator`, `UniqueByField` makes
   modifications __in place__ in all situations.  There is no inconsistency in this
   case.  However, if the intention is that these functions also return copies, than
   they still need to be reviewed.
2) The function `SymmetricDifference` uses Unique on the input slice.  That makes it
   indirectly inconsistent.  This fixes addressed that.
3) Functions in the slice_concurrent.go file do not have this inconsistency.